### PR TITLE
core: explicit chmod temp files

### DIFF
--- a/ovirt_engine_kerbldap_migration/authz_rename/__main__.py
+++ b/ovirt_engine_kerbldap_migration/authz_rename/__main__.py
@@ -190,6 +190,7 @@ def overrideAuthz(args, engine):
                             filetransaction.getFileName(fpath),
                             'w'
                         ) as f:
+                            os.chmod(f.name, 0o644)
                             f.write(newcontent)
                         aaadao.update(
                             args.authzName,

--- a/ovirt_engine_kerbldap_migration/tool/__main__.py
+++ b/ovirt_engine_kerbldap_migration/tool/__main__.py
@@ -704,6 +704,7 @@ class AAAProfile(utils.Base):
             ),
             'w',
         ) as f:
+            os.chmod(f.name, 0o644)
             _writelog(
                 f,
                 (
@@ -730,6 +731,7 @@ class AAAProfile(utils.Base):
             ),
             'w',
         ) as f:
+            os.chmod(f.name, 0o644)
             _writelog(
                 f,
                 (


### PR DESCRIPTION
the mkstemp creates files with 0600 mode, we need to explicit modify
mode at all usages of file transactions.